### PR TITLE
Add support for scss extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var sass = require('node-sass'),
     path = require('path'),
     deferred = require('deferred');
 
-exports.extension = ['sass'];
+exports.extension = ['sass', 'scss'];
 exports.type = 'css';
 
 function compileSass(src, info) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmake-sass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Require SASS files with Webmake",
   "keywords": [
     "browser",


### PR DESCRIPTION
node-sass supports the scss syntax -- however if it is required, webmake-sass is unable to find it because the extension only has `sass`
